### PR TITLE
Add support to Github Markdown (ghmarkdown)

### DIFF
--- a/ftplugin/markdown_tagbar.vim
+++ b/ftplugin/markdown_tagbar.vim
@@ -44,6 +44,8 @@ let g:tagbar_type_markdown = {
     \}
 \}
 
+let g:tagbar_type_ghmarkdown = g:tagbar_type_markdown
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 


### PR DESCRIPTION
This adds an alias to support Github Markdown file type.